### PR TITLE
feat: prepare for 1.2.0 release

### DIFF
--- a/packages/wordclock-js/.releaserc.json
+++ b/packages/wordclock-js/.releaserc.json
@@ -15,6 +15,5 @@
   "git": {
     "assets": false,
     "requireCleanWorkingDir": false
-  },
-  "tagFormat": "wordclock-js@${version}"
+  }
 }

--- a/packages/wordclock-js/package.json
+++ b/packages/wordclock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simonheys/wordclock",
-  "version": "1.1.7",
+  "version": "1.2.0",
   "private": false,
   "author": "Simon Heys <si@simonheys.com>",
   "license": "MIT",

--- a/packages/wordclock-words/.releaserc.json
+++ b/packages/wordclock-words/.releaserc.json
@@ -15,6 +15,5 @@
   "git": {
     "assets": false,
     "requireCleanWorkingDir": false
-  },
-  "tagFormat": "wordclock-words@${version}"
+  }
 }


### PR DESCRIPTION
BREAKING CHANGE: Changed tag format to include package name
- wordclock-js@x.y.z
- wordclock-words@x.y.z