### PR TITLE
fix: process not exiting when running on Sonoma

### DIFF
--- a/packages/wordclock-macos/Word Clock Screen Saver/WordClockScreenSaverView.m
+++ b/packages/wordclock-macos/Word Clock Screen Saver/WordClockScreenSaverView.m
@@ -47,6 +47,15 @@
 
 - (instancetype)initWithFrame:(NSRect)frame isPreview:(BOOL)isPreview {
     self = [super initWithFrame:frame isPreview:isPreview];
+    if (!isPreview) {
+      [[NSDistributedNotificationCenter defaultCenter]
+          addObserverForName: @"com.apple.screensaver.willstop"
+                      object: nil
+                       queue: nil
+                  usingBlock:^(NSNotification *n) {
+          [[NSApplication sharedApplication] terminate: self];
+        }];
+    }
     if (self) {
         WCFileFunctionLevelFormatter *fileFunctionLevelFormatter = [WCFileFunctionLevelFormatter new];
         [[DDTTYLogger sharedInstance] setLogFormatter:fileFunctionLevelFormatter];


### PR DESCRIPTION
As detailed in [this post](https://www.jwz.org/blog/2023/10/xscreensaver-6-08-out-now/) and [this other post](https://zsmb.co/building-a-macos-screen-saver-in-kotlin/#macos-sonoma), legacy screen savers on macOS Sonoma will continue running in the background even after the screen saver stops running. With this change, the process should exit properly after the screen saver is deactivated. Fixes #256 and #293.