### PR TITLE
refactor: remove lodash from react package

### DIFF
--- a/packages/wordclock-js/package.json
+++ b/packages/wordclock-js/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@simonheys/wordclock-words": "*",
-    "lodash-es": "4.17.21",
     "resize-observer-polyfill": "1.5.1"
   },
   "devDependencies": {
@@ -34,8 +33,6 @@
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",
-    "@types/lodash": "4.17.21",
-    "@types/lodash-es": "4.17.12",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@typescript-eslint/eslint-plugin": "8.50.0",
@@ -46,7 +43,6 @@
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "7.0.1",
     "happy-dom": "20.9.0",
-    "lodash": "4.17.21",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "semantic-release": "25.0.2",

--- a/packages/wordclock-js/src/modules/LogicParser.test.ts
+++ b/packages/wordclock-js/src/modules/LogicParser.test.ts
@@ -15,6 +15,10 @@ describe('LogicParser', () => {
           expect(processTerm('false')).toEqual(false)
         })
       })
+      it('accepts String objects', () => {
+        // @ts-expect-error testing compatibility with previous string guard behavior
+        expect(processTerm(new String(' true '))).toEqual(true)
+      })
     })
     describe('when invalid', () => {
       it('returns empty string', () => {

--- a/packages/wordclock-js/src/modules/LogicParser.ts
+++ b/packages/wordclock-js/src/modules/LogicParser.ts
@@ -1,4 +1,3 @@
-import { isString } from 'lodash-es'
 import * as LogicParserStringUtil from './LogicParserStringUtil'
 
 // /** Extract the 'data' type of each item in the union if it exists */
@@ -27,6 +26,10 @@ export type AllOperatorValues = ExtractArrayValues<Operators[OperatorKeys]>
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Result = any
 type Props = Record<string, Result>
+
+const objectToString = Object.prototype.toString
+const isString = (value: unknown): value is string =>
+  typeof value === 'string' || objectToString.call(value) === '[object String]'
 
 export const term = (source: string, props?: Props) => {
   let terms

--- a/packages/wordclock-js/src/modules/LogicParserStringUtil.test.ts
+++ b/packages/wordclock-js/src/modules/LogicParserStringUtil.test.ts
@@ -71,6 +71,15 @@ describe('LogicParserStringUtil', () => {
         expect(countInstancesOf()).toEqual(0)
       })
     })
+    it('accepts String objects', () => {
+      expect(
+        countInstancesOf({
+          // @ts-expect-error testing compatibility with previous string guard behavior
+          source: new String('1001'),
+          instance: '1',
+        }),
+      ).toEqual(2)
+    })
   })
 
   describe('checkBalancedBraces', () => {

--- a/packages/wordclock-js/src/modules/LogicParserStringUtil.ts
+++ b/packages/wordclock-js/src/modules/LogicParserStringUtil.ts
@@ -1,6 +1,8 @@
-import { isArray, isString } from 'lodash-es'
-
 export const OPERATORS = '!%&*()-+=|/<>'
+
+const objectToString = Object.prototype.toString
+const isString = (value: unknown): value is string =>
+  typeof value === 'string' || objectToString.call(value) === '[object String]'
 
 export const isNumericString = (string: string) => {
   return /^-?\d+$/.test(string)
@@ -49,7 +51,7 @@ export const scanForInstanceOf = ({
   source?: string
   array?: string[] | readonly string[]
 } = {}) => {
-  if (!isString(source) || !isArray(array)) {
+  if (!isString(source) || !Array.isArray(array)) {
     return -1
   }
   for (let i = 0; i < array.length; i++) {

--- a/packages/wordclock-js/vite.config.mts
+++ b/packages/wordclock-js/vite.config.mts
@@ -4,13 +4,7 @@ import react from '@vitejs/plugin-react-swc'
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
 
-const external = [
-  'lodash-es',
-  'react',
-  'react-dom',
-  'react/jsx-runtime',
-  'resize-observer-polyfill',
-]
+const external = ['react', 'react-dom', 'react/jsx-runtime', 'resize-observer-polyfill']
 const clientDirective = "'use client';"
 
 export default defineConfig(({ mode }) => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,9 +125,6 @@ importers:
       '@simonheys/wordclock-words':
         specifier: '*'
         version: 1.1.7
-      lodash-es:
-        specifier: 4.17.21
-        version: 4.17.21
       resize-observer-polyfill:
         specifier: 1.5.1
         version: 1.5.1
@@ -156,12 +153,6 @@ importers:
       '@testing-library/user-event':
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.1.0)
-      '@types/lodash':
-        specifier: 4.17.21
-        version: 4.17.21
-      '@types/lodash-es':
-        specifier: 4.17.12
-        version: 4.17.12
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
@@ -192,9 +183,6 @@ importers:
       happy-dom:
         specifier: 20.9.0
         version: 20.9.0
-      lodash:
-        specifier: 4.17.21
-        version: 4.17.21
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1392,12 +1380,6 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
-
-  '@types/lodash-es@4.17.12':
-    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
-
-  '@types/lodash@4.17.21':
-    resolution: {integrity: sha512-FOvQ0YPD5NOfPgMzJihoT+Za5pdkDJWcbpuj1DjaKZIr/gxodQjY/uWEFlTNqW2ugXHUiL8lRQgw63dzKHZdeQ==}
 
   '@types/node@24.10.4':
     resolution: {integrity: sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==}
@@ -5616,12 +5598,6 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
-
-  '@types/lodash-es@4.17.12':
-    dependencies:
-      '@types/lodash': 4.17.21
-
-  '@types/lodash@4.17.21': {}
 
   '@types/node@24.10.4':
     dependencies:


### PR DESCRIPTION
## Summary
- replace lodash string/array guards in the React package parser with local/native checks
- remove lodash runtime/dev dependencies and Vite external entry
- add regression coverage for boxed String compatibility preserved by the local guard

## Verification
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/eslint .
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/vite build
- env npm_config_cache=/private/tmp/wordclock-npm-cache npm pack --dry-run --json --ignore-scripts