### PR TITLE
fix: stabilize word clock fitting and hydration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ When creating or updating a pull request, write for reviewer throughput and futu
 - Structure the description with `Summary`, `Why`, `Review Notes`, `Validation`, and `Risk` when the change is non-trivial.
 - Explain both what changed and why it was needed. Include important tradeoffs that are not obvious from the diff.
 - Give reviewers a map when multiple areas changed: where to start, what files matter most, and what deserves extra scrutiny.
-- List concrete validation commands and manual checks. Say clearly when something was not tested.
+- List concrete validation commands and manual checks. Prefer project/package scripts over direct local binary paths or sandbox-specific workaround commands. Say clearly when something was not tested.
 - Avoid machine-specific details in pull request text, including absolute local paths, personal usernames, local hostnames, and incidental ports. Use project-relative paths and generic local-server descriptions instead.
 - Link related issues, pull requests, design notes, or follow-up work when available.
 - Do not add screenshots unless visual appearance is part of the review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent Instructions
+
+## Pull Request Authoring
+
+When creating or updating a pull request, write for reviewer throughput and future history.
+
+- Keep the pull request focused on one purpose. If the work has unrelated parts, split it or call out the boundary clearly.
+- Use a specific title that says what changed.
+- Structure the description with `Summary`, `Why`, `Review Notes`, `Validation`, and `Risk` when the change is non-trivial.
+- Explain both what changed and why it was needed. Include important tradeoffs that are not obvious from the diff.
+- Give reviewers a map when multiple areas changed: where to start, what files matter most, and what deserves extra scrutiny.
+- List concrete validation commands and manual checks. Say clearly when something was not tested.
+- Link related issues, pull requests, design notes, or follow-up work when available.
+- Do not add screenshots unless visual appearance is part of the review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,5 +10,6 @@ When creating or updating a pull request, write for reviewer throughput and futu
 - Explain both what changed and why it was needed. Include important tradeoffs that are not obvious from the diff.
 - Give reviewers a map when multiple areas changed: where to start, what files matter most, and what deserves extra scrutiny.
 - List concrete validation commands and manual checks. Say clearly when something was not tested.
+- Avoid machine-specific details in pull request text, including absolute local paths, personal usernames, local hostnames, and incidental ports. Use project-relative paths and generic local-server descriptions instead.
 - Link related issues, pull requests, design notes, or follow-up work when available.
 - Do not add screenshots unless visual appearance is part of the review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ When creating or updating a pull request, write for reviewer throughput and futu
 - Structure the description with `Summary`, `Why`, `Review Notes`, `Validation`, and `Risk` when the change is non-trivial.
 - Explain both what changed and why it was needed. Include important tradeoffs that are not obvious from the diff.
 - Give reviewers a map when multiple areas changed: where to start, what files matter most, and what deserves extra scrutiny.
-- List concrete validation commands and manual checks. Prefer project/package scripts over direct local binary paths or sandbox-specific workaround commands. Say clearly when something was not tested.
-- Avoid machine-specific details in pull request text, including absolute local paths, personal usernames, local hostnames, and incidental ports. Use project-relative paths and generic local-server descriptions instead.
+- Make validation reproducible. Cite the project's stable interface for checks, such as package scripts, task runners, documented workflows, or CI job names. If validation was manual, describe the user-visible behavior that was checked.
+- Keep pull request text portable. Avoid environment details that do not help a reviewer understand or reproduce the change, such as absolute local paths, personal accounts, hostnames, ephemeral ports, or shell-specific setup. Use repo-relative paths and stable project commands instead.
 - Link related issues, pull requests, design notes, or follow-up work when available.
 - Do not add screenshots unless visual appearance is part of the review.

--- a/apps/example/e2e/word-clock-fit.spec.ts
+++ b/apps/example/e2e/word-clock-fit.spec.ts
@@ -1,0 +1,81 @@
+import { expect, type Locator, test } from '@playwright/test'
+
+type FitMetrics = {
+  clientHeight: number
+  fontSize: number
+  scrollHeight: number
+}
+
+const fitTolerance = 1
+const fontSizeTolerance = 0.5
+const minimumFittedFontSize = 20
+
+test.use({
+  deviceScaleFactor: 2,
+  viewport: {
+    height: 916,
+    width: 570,
+  },
+})
+
+const getFitMetrics = async (locator: Locator) =>
+  locator.evaluate((element: HTMLElement): FitMetrics => {
+    return {
+      clientHeight: element.clientHeight,
+      fontSize: Number.parseFloat(getComputedStyle(element).fontSize),
+      scrollHeight: element.scrollHeight,
+    }
+  })
+
+const expectToFit = async (locator: Locator) => {
+  await expect
+    .poll(async () => {
+      const { clientHeight, scrollHeight } = await getFitMetrics(locator)
+      return scrollHeight - clientHeight
+    })
+    .toBeLessThanOrEqual(fitTolerance)
+}
+
+const expectFontSizeGreaterThan = async (locator: Locator, fontSize: number) => {
+  await expect
+    .poll(async () => {
+      const { fontSize } = await getFitMetrics(locator)
+      return fontSize
+    })
+    .toBeGreaterThan(fontSize)
+}
+
+const expectFontSizeLessThan = async (locator: Locator, fontSize: number) => {
+  await expect
+    .poll(async () => {
+      const { fontSize } = await getFitMetrics(locator)
+      return fontSize
+    })
+    .toBeLessThan(fontSize)
+}
+
+test('word clock refits when its container width changes', async ({ page }) => {
+  await page.goto('/')
+
+  const frame = page.getByTestId('word-clock-frame')
+  const words = page.getByTestId('word-clock-words')
+
+  await expectFontSizeGreaterThan(words, minimumFittedFontSize)
+  await expectToFit(words)
+  const initialMetrics = await getFitMetrics(words)
+
+  await frame.evaluate((element: HTMLElement) => {
+    element.style.width = '320px'
+  })
+
+  await expectFontSizeLessThan(words, initialMetrics.fontSize - fontSizeTolerance)
+  await expectToFit(words)
+  const narrowMetrics = await getFitMetrics(words)
+
+  await frame.evaluate((element: HTMLElement) => {
+    element.style.width = '100%'
+  })
+
+  await expectFontSizeGreaterThan(words, narrowMetrics.fontSize + fontSizeTolerance)
+  await expectToFit(words)
+})

--- a/apps/example/next.config.mjs
+++ b/apps/example/next.config.mjs
@@ -1,4 +1,13 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  turbopack: {
+    root: resolve(__dirname, '../..'),
+  },
+}
 
 export default nextConfig

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test:e2e": "playwright test",
     "lint": "eslint ."
   },
   "dependencies": {
@@ -16,6 +17,7 @@
     "react-dom": "19.2.6"
   },
   "devDependencies": {
+    "@playwright/test": "1.59.1",
     "@simonheys/eslint-config": "workspace:*",
     "@tailwindcss/postcss": "4.2.4",
     "@types/node": "24.10.4",

--- a/apps/example/playwright.config.mjs
+++ b/apps/example/playwright.config.mjs
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test'
+import { dirname, resolve } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(__dirname, '../..')
+const port = Number(process.env.PORT ?? 3100)
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${port}`
+const webServer = process.env.PLAYWRIGHT_BASE_URL
+  ? undefined
+  : {
+      command: `pnpm --filter @simonheys/wordclock build && pnpm --filter @simonheys/wordclock-example dev --hostname 127.0.0.1 --port ${port}`,
+      cwd: repositoryRoot,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120000,
+      url: baseURL,
+    }
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['github'], ['list']] : 'list',
+  use: {
+    baseURL,
+    screenshot: 'off',
+    trace: 'off',
+    video: 'off',
+  },
+  webServer,
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/apps/example/src/app/page.tsx
+++ b/apps/example/src/app/page.tsx
@@ -95,11 +95,12 @@ export default function Home() {
         </select>
       </div>
       <div
-        className="w-full bg-gray-100 leading-[1.1] font-bold tracking-tight text-gray-400 [font-feature-settings:'liga'_1,'kern'_1] dark:bg-gray-900 dark:text-gray-700"
+        data-testid="word-clock-frame"
+        className="w-full bg-gray-100 [font-feature-settings:'liga'_1,'kern'_1] leading-[1.1] font-bold tracking-tight text-gray-400 dark:bg-gray-900 dark:text-gray-700"
         style={{ height: `${height}px` }}
       >
         {mounted && (
-          <WordClock words={words}>
+          <WordClock data-testid="word-clock-words" words={words}>
             <WordClockContent />
           </WordClock>
         )}

--- a/packages/wordclock-js/src/components/WordClock.test.tsx
+++ b/packages/wordclock-js/src/components/WordClock.test.tsx
@@ -1,4 +1,5 @@
 import { act, cleanup, render, screen } from '@testing-library/react'
+import { renderToString } from 'react-dom/server'
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 
 import json from '@simonheys/wordclock-words/json/English.json'
@@ -62,6 +63,19 @@ test('passes HTML attributes to the rendered words container', () => {
     height: '100%',
     alignContent: 'space-between',
   })
+})
+
+test('does not render time-dependent highlights during server render', () => {
+  vi.setSystemTime(new Date(2024, 0, 1, 12, 0, 0))
+
+  const html = renderToString(
+    <WordClock words={secondsWords}>
+      <WordClockContent />
+    </WordClock>,
+  )
+
+  expect(html).toContain('zero seconds')
+  expect(html).not.toContain('#ff0000')
 })
 
 test('highlights words for the current second and updates every second', () => {

--- a/packages/wordclock-js/src/components/WordClockContent.tsx
+++ b/packages/wordclock-js/src/components/WordClockContent.tsx
@@ -20,7 +20,7 @@ export const WordClockContent: FC<WordClockContentProps> = ({
         // only allow a single highlight per group
         return labelGroup.map((label, labelGroupIndex) => {
           highlighted = false
-          if (!hasPreviousHighlight) {
+          if (timeProps && !hasPreviousHighlight) {
             const logic = logicGroup[labelGroupIndex]
             highlighted = LogicParser.term(logic, timeProps)
             if (highlighted) {

--- a/packages/wordclock-js/src/components/useWordClock.ts
+++ b/packages/wordclock-js/src/components/useWordClock.ts
@@ -5,7 +5,7 @@ import { WordsLabel, WordsLogic } from './types'
 interface WordClockContentProps {
   logic: WordsLogic
   label: WordsLabel
-  timeProps: TimeProps
+  timeProps: TimeProps | null
 }
 
 const WordClockContext = createContext<WordClockContentProps | null>(null)

--- a/packages/wordclock-js/src/hooks/useResizeTextToFit.test.ts
+++ b/packages/wordclock-js/src/hooks/useResizeTextToFit.test.ts
@@ -1,0 +1,165 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, expect, vi } from 'vitest'
+
+const useSizeMock = vi.hoisted(() => ({
+  containerRef: vi.fn(),
+  size: {
+    height: 100,
+    width: 100,
+  },
+}))
+
+vi.mock('./useSize', () => ({
+  default: () => ({
+    ref: useSizeMock.containerRef,
+    size: useSizeMock.size,
+  }),
+}))
+
+import {
+  fitTextToHeight,
+  getFontSizeAdjustmentThreshold,
+  useResizeTextToFit,
+} from './useResizeTextToFit'
+
+const parseFontSize = (element: HTMLElement) => Number.parseFloat(element.style.fontSize)
+
+const createMeasuredElement = () => {
+  const element = document.createElement('div')
+
+  Object.defineProperty(element, 'scrollHeight', {
+    configurable: true,
+    get() {
+      return parseFontSize(element) * 2
+    },
+  })
+
+  return element
+}
+
+describe('getFontSizeAdjustmentThreshold', () => {
+  it('uses rendered pixel precision based on device pixel ratio', () => {
+    expect(getFontSizeAdjustmentThreshold(1)).toEqual(1)
+    expect(getFontSizeAdjustmentThreshold(2)).toEqual(0.5)
+  })
+
+  it('falls back to one CSS pixel for invalid device pixel ratios', () => {
+    expect(getFontSizeAdjustmentThreshold(0)).toEqual(1)
+  })
+})
+
+describe('fitTextToHeight', () => {
+  it('sets the largest fitting font size within the supplied precision', () => {
+    const element = createMeasuredElement()
+
+    fitTextToHeight(element, 100, 1)
+
+    expect(parseFontSize(element)).toBeGreaterThan(49)
+    expect(parseFontSize(element)).toBeLessThanOrEqual(50)
+  })
+
+  it('restores an existing inline height after measurement', () => {
+    const element = createMeasuredElement()
+    element.style.height = '25px'
+
+    fitTextToHeight(element, 100, 1)
+
+    expect(element.style.height).toEqual('25px')
+  })
+
+  it('removes the temporary inline height when no height was set', () => {
+    const element = createMeasuredElement()
+
+    fitTextToHeight(element, 100, 1)
+
+    expect(element.style.height).toEqual('')
+  })
+
+  it('does not mutate font size without a target height', () => {
+    const element = createMeasuredElement()
+
+    fitTextToHeight(element, 0, 1)
+
+    expect(element.style.fontSize).toEqual('')
+  })
+})
+
+describe('useResizeTextToFit', () => {
+  let animationFrameCallbacks: FrameRequestCallback[]
+  let originalFonts: FontFaceSet | undefined
+
+  beforeEach(() => {
+    animationFrameCallbacks = []
+    useSizeMock.size = {
+      height: 100,
+      width: 100,
+    }
+    originalFonts = document.fonts
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      value: undefined,
+    })
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      animationFrameCallbacks.push(callback)
+      return animationFrameCallbacks.length
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((frameId) => {
+      animationFrameCallbacks[frameId - 1] = () => undefined
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      value: originalFonts,
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('coalesces resize requests into a single animation frame', () => {
+    const { result } = renderHook(() => useResizeTextToFit())
+    const initialFrame = animationFrameCallbacks.shift()
+    act(() => {
+      initialFrame?.(0)
+    })
+
+    const requestedFramesBeforeResize = vi.mocked(window.requestAnimationFrame).mock.calls.length
+    const element = createMeasuredElement()
+    result.current.resizeRef.current = element
+
+    act(() => {
+      result.current.resize()
+      result.current.resize()
+    })
+
+    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(requestedFramesBeforeResize + 1)
+    expect(element.style.fontSize).toEqual('')
+
+    const resizeFrame = animationFrameCallbacks.shift()
+    act(() => {
+      resizeFrame?.(0)
+    })
+
+    expect(parseFontSize(element)).toBeGreaterThan(49)
+    expect(parseFontSize(element)).toBeLessThanOrEqual(50)
+  })
+
+  it('schedules a refit when only the measured width changes', () => {
+    const { rerender } = renderHook(() => useResizeTextToFit())
+    const initialFrame = animationFrameCallbacks.shift()
+    act(() => {
+      initialFrame?.(0)
+    })
+
+    const requestedFramesBeforeResize = vi.mocked(window.requestAnimationFrame).mock.calls.length
+
+    useSizeMock.size = {
+      ...useSizeMock.size,
+      width: 200,
+    }
+
+    rerender()
+
+    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(requestedFramesBeforeResize + 1)
+  })
+})

--- a/packages/wordclock-js/src/hooks/useResizeTextToFit.ts
+++ b/packages/wordclock-js/src/hooks/useResizeTextToFit.ts
@@ -2,70 +2,131 @@ import { useCallback, useEffect, useRef } from 'react'
 
 import useSize from './useSize'
 
-const minimumFontSizeAdjustment = 0.0001
+const minimumFontSize = 1
+const maximumFontSize = 256
+const defaultDevicePixelRatio = 1
+
+export const getFontSizeAdjustmentThreshold = (
+  devicePixelRatio = globalThis.window?.devicePixelRatio ?? defaultDevicePixelRatio,
+) => 1 / Math.max(devicePixelRatio || defaultDevicePixelRatio, defaultDevicePixelRatio)
+
+const requestResizeFrame = (callback: FrameRequestCallback) => {
+  if (!globalThis.window?.requestAnimationFrame) {
+    callback(0)
+    return null
+  }
+  return window.requestAnimationFrame(callback)
+}
+
+const cancelResizeFrame = (frameId: number | null) => {
+  if (frameId !== null && globalThis.window) {
+    window.cancelAnimationFrame(frameId)
+  }
+}
+
+export const fitTextToHeight = (
+  element: HTMLDivElement,
+  targetHeight: number,
+  minimumFontSizeAdjustment = getFontSizeAdjustmentThreshold(),
+) => {
+  if (!targetHeight) {
+    return
+  }
+
+  const originalHeight = element.style.height || null
+  element.style.height = 'auto'
+
+  let fontSizeLow = minimumFontSize
+  let fontSizeHigh = maximumFontSize
+  let done = false
+  let oldLow = -1
+  let oldHigh = -1
+  let lowFits = false,
+    highFits = false,
+    midFits = false
+  let fontSizeMid
+
+  while (!done && Math.abs(fontSizeLow - fontSizeHigh) > minimumFontSizeAdjustment) {
+    if (fontSizeLow !== oldLow) {
+      element.style.fontSize = `${fontSizeLow}px`
+      lowFits = element.scrollHeight < targetHeight
+      oldLow = fontSizeLow
+    }
+    if (fontSizeHigh !== oldHigh) {
+      element.style.fontSize = `${fontSizeHigh}px`
+      highFits = element.scrollHeight < targetHeight
+      oldHigh = fontSizeHigh
+    }
+    if (lowFits && !highFits) {
+      fontSizeMid = (fontSizeLow + fontSizeHigh) * 0.5
+      element.style.fontSize = `${fontSizeMid}px`
+      midFits = element.scrollHeight < targetHeight
+      if (midFits) {
+        fontSizeLow = fontSizeMid
+      } else {
+        fontSizeHigh = fontSizeMid
+      }
+    } else {
+      done = true
+    }
+  }
+
+  element.style.fontSize = `${fontSizeLow}px`
+
+  if (originalHeight) {
+    element.style.height = originalHeight
+  } else {
+    element.style.removeProperty('height')
+  }
+}
 
 export const useResizeTextToFit = () => {
   const { ref: containerRef, size: targetSize } = useSize()
   const resizeRef = useRef<HTMLDivElement>(null)
-  const originalHeightRef = useRef<string | null>(null)
+  const resizeFrameRef = useRef<number | null>(null)
+
+  const runResize = useCallback(() => {
+    resizeFrameRef.current = null
+    if (resizeRef.current && targetSize.width) {
+      fitTextToHeight(resizeRef.current, targetSize.height)
+    }
+  }, [targetSize.height, targetSize.width])
 
   const resize = useCallback(() => {
-    if (!resizeRef.current || !targetSize.height) {
+    if (resizeFrameRef.current !== null) {
       return
     }
-
-    // Store original height before modifying
-    originalHeightRef.current = resizeRef.current.style.height || null
-    resizeRef.current.style.height = 'auto'
-
-    let fontSizeLow = 1
-    let fontSizeHigh = 256
-    let done = false
-    let oldLow = -1
-    let oldHigh = -1
-    let lowFits = false,
-      highFits = false,
-      midFits = false
-    let fontSizeMid
-
-    while (!done && Math.abs(fontSizeLow - fontSizeHigh) > minimumFontSizeAdjustment) {
-      if (fontSizeLow !== oldLow) {
-        resizeRef.current.style.fontSize = `${fontSizeLow}px`
-        lowFits = resizeRef.current.scrollHeight < targetSize.height
-        oldLow = fontSizeLow
-      }
-      if (fontSizeHigh !== oldHigh) {
-        resizeRef.current.style.fontSize = `${fontSizeHigh}px`
-        highFits = resizeRef.current.scrollHeight < targetSize.height
-        oldHigh = fontSizeHigh
-      }
-      if (lowFits && !highFits) {
-        fontSizeMid = (fontSizeLow + fontSizeHigh) * 0.5
-        resizeRef.current.style.fontSize = `${fontSizeMid}px`
-        midFits = resizeRef.current.scrollHeight < targetSize.height
-        if (midFits) {
-          fontSizeLow = fontSizeMid
-        } else {
-          fontSizeHigh = fontSizeMid
-        }
-      } else {
-        done = true
-      }
-    }
-
-    resizeRef.current.style.fontSize = `${fontSizeLow}px`
-
-    // Restore original height or remove the property
-    if (originalHeightRef.current) {
-      resizeRef.current.style.height = originalHeightRef.current
-    } else {
-      resizeRef.current.style.removeProperty('height')
-    }
-  }, [targetSize])
+    resizeFrameRef.current = requestResizeFrame(runResize)
+  }, [runResize])
 
   useEffect(() => {
     resize()
-  }, [resize, targetSize])
+    return () => {
+      cancelResizeFrame(resizeFrameRef.current)
+      resizeFrameRef.current = null
+    }
+  }, [resize])
+
+  useEffect(() => {
+    const fonts = globalThis.document?.fonts
+    if (!fonts) {
+      return
+    }
+
+    let cancelled = false
+    const resizeAfterFontsLoad = () => {
+      if (!cancelled) {
+        resize()
+      }
+    }
+
+    void fonts.ready.then(resizeAfterFontsLoad)
+    fonts.addEventListener('loadingdone', resizeAfterFontsLoad)
+    return () => {
+      cancelled = true
+      fonts.removeEventListener('loadingdone', resizeAfterFontsLoad)
+    }
+  }, [resize])
 
   return {
     resizeRef,

--- a/packages/wordclock-js/src/hooks/useSize.test.tsx
+++ b/packages/wordclock-js/src/hooks/useSize.test.tsx
@@ -1,0 +1,67 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, expect, test, vi } from 'vitest'
+
+const resizeObserverMock = vi.hoisted(() => ({
+  callback: undefined as ResizeObserverCallback | undefined,
+  disconnect: vi.fn(),
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+}))
+
+vi.mock('resize-observer-polyfill', () => ({
+  default: vi.fn(function ResizeObserver(callback: ResizeObserverCallback) {
+    resizeObserverMock.callback = callback
+
+    return {
+      disconnect: resizeObserverMock.disconnect,
+      observe: resizeObserverMock.observe,
+      unobserve: resizeObserverMock.unobserve,
+    }
+  }),
+}))
+
+import useSize from './useSize'
+
+const createResizeObserverEntry = (
+  target: Element,
+  contentRect: Pick<DOMRectReadOnly, 'height' | 'width'>,
+) =>
+  ({
+    contentRect,
+    target,
+  }) as ResizeObserverEntry
+
+afterEach(() => {
+  resizeObserverMock.callback = undefined
+  vi.clearAllMocks()
+})
+
+test('preserves the size object when the observed dimensions are unchanged', () => {
+  const { result } = renderHook(() => useSize())
+  const element = document.createElement('div')
+  const entry = createResizeObserverEntry(element, {
+    height: 50,
+    width: 100,
+  })
+
+  act(() => {
+    result.current.ref(element)
+  })
+
+  act(() => {
+    resizeObserverMock.callback?.([entry], {} as ResizeObserver)
+  })
+
+  expect(result.current.size).toEqual({
+    height: 50,
+    width: 100,
+  })
+
+  const sizeAfterFirstResize = result.current.size
+
+  act(() => {
+    resizeObserverMock.callback?.([entry], {} as ResizeObserver)
+  })
+
+  expect(result.current.size).toBe(sizeAfterFirstResize)
+})

--- a/packages/wordclock-js/src/hooks/useSize.test.tsx
+++ b/packages/wordclock-js/src/hooks/useSize.test.tsx
@@ -34,9 +34,12 @@ const createResizeObserverEntry = (
 afterEach(() => {
   resizeObserverMock.callback = undefined
   vi.clearAllMocks()
+  vi.unstubAllGlobals()
 })
 
-test('preserves the size object when the observed dimensions are unchanged', () => {
+test('uses the polyfill when native ResizeObserver is unavailable', () => {
+  vi.stubGlobal('ResizeObserver', undefined)
+
   const { result } = renderHook(() => useSize())
   const element = document.createElement('div')
   const entry = createResizeObserverEntry(element, {
@@ -64,4 +67,46 @@ test('preserves the size object when the observed dimensions are unchanged', () 
   })
 
   expect(result.current.size).toBe(sizeAfterFirstResize)
+})
+
+test('uses native ResizeObserver when available', () => {
+  const nativeResizeObserverMock = {
+    callback: undefined as ResizeObserverCallback | undefined,
+    disconnect: vi.fn(),
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+  }
+  const NativeResizeObserver = vi.fn(function ResizeObserver(callback: ResizeObserverCallback) {
+    nativeResizeObserverMock.callback = callback
+
+    return {
+      disconnect: nativeResizeObserverMock.disconnect,
+      observe: nativeResizeObserverMock.observe,
+      unobserve: nativeResizeObserverMock.unobserve,
+    }
+  })
+  vi.stubGlobal('ResizeObserver', NativeResizeObserver)
+
+  const { result } = renderHook(() => useSize())
+  const element = document.createElement('div')
+  const entry = createResizeObserverEntry(element, {
+    height: 75,
+    width: 125,
+  })
+
+  act(() => {
+    result.current.ref(element)
+  })
+
+  expect(NativeResizeObserver).toHaveBeenCalledTimes(1)
+  expect(resizeObserverMock.observe).not.toHaveBeenCalled()
+
+  act(() => {
+    nativeResizeObserverMock.callback?.([entry], {} as ResizeObserver)
+  })
+
+  expect(result.current.size).toEqual({
+    height: 75,
+    width: 125,
+  })
 })

--- a/packages/wordclock-js/src/hooks/useSize.ts
+++ b/packages/wordclock-js/src/hooks/useSize.ts
@@ -1,5 +1,10 @@
 import * as React from 'react'
-import ResizeObserver from 'resize-observer-polyfill'
+import ResizeObserverPolyfill from 'resize-observer-polyfill'
+
+const createResizeObserver = (callback: ResizeObserverCallback) => {
+  const ResizeObserverImplementation = globalThis.ResizeObserver ?? ResizeObserverPolyfill
+  return new ResizeObserverImplementation(callback)
+}
 
 const useSize = () => {
   const ref = React.useRef<HTMLDivElement | null>(null)
@@ -26,7 +31,7 @@ const useSize = () => {
     if (!ref.current) {
       return
     }
-    resizeObserver.current = new ResizeObserver((entries) => {
+    resizeObserver.current = createResizeObserver((entries) => {
       const currentRefEntry = entries.find(({ target }) => target === ref.current)
       if (currentRefEntry) {
         const { width, height } = currentRefEntry.contentRect

--- a/packages/wordclock-js/src/hooks/useSize.ts
+++ b/packages/wordclock-js/src/hooks/useSize.ts
@@ -30,14 +30,19 @@ const useSize = () => {
       const currentRefEntry = entries.find(({ target }) => target === ref.current)
       if (currentRefEntry) {
         const { width, height } = currentRefEntry.contentRect
-        setSize({ width, height })
+        setSize((currentSize) => {
+          if (currentSize.width === width && currentSize.height === height) {
+            return currentSize
+          }
+          return { width, height }
+        })
       }
     })
     resizeObserver.current.observe(ref.current)
   }, [teardownResizeObserver])
 
   const setRef = React.useCallback(
-    (nextRef: HTMLDivElement) => {
+    (nextRef: HTMLDivElement | null) => {
       teardownResizeObserver()
       ref.current = nextRef
       setupResizeObserver()

--- a/packages/wordclock-js/src/hooks/useTimeProps.ts
+++ b/packages/wordclock-js/src/hooks/useTimeProps.ts
@@ -29,11 +29,14 @@ export const getTimeProps = (dateInstance = new Date()) => {
 }
 
 const useTimeProps = () => {
-  const [timeProps, setTimeProps] = useState(getTimeProps())
+  const [timeProps, setTimeProps] = useState<TimeProps | null>(null)
   useEffect(() => {
-    const interval = setInterval(() => {
+    const updateTimeProps = () => {
       setTimeProps(getTimeProps())
-    }, 1000)
+    }
+
+    updateTimeProps()
+    const interval = setInterval(updateTimeProps, 1000)
     return () => clearInterval(interval)
   }, [])
   return timeProps

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: link:../../packages/wordclock-words
       next:
         specifier: 16.2.6
-        version: 16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.80.3)
+        version: 16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.80.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -51,6 +51,9 @@ importers:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
     devDependencies:
+      '@playwright/test':
+        specifier: 1.59.1
+        version: 1.59.1
       '@simonheys/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config
@@ -936,6 +939,11 @@ packages:
   '@parcel/watcher@2.5.1':
     resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
     engines: {node: '>= 10.0.0'}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -2438,6 +2446,11 @@ packages:
     resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3520,6 +3533,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
@@ -5199,6 +5222,10 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.5.1
     optional: true
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/network.ca-file@1.0.2':
@@ -6681,7 +6708,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.0(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -6708,13 +6735,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
       enhanced-resolve: 5.18.4
       eslint: 9.39.2(jiti@2.6.1)
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.6.1))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -6727,13 +6754,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -6748,7 +6775,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7025,6 +7052,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -7768,7 +7798,7 @@ snapshots:
 
   nerf-dart@1.0.0: {}
 
-  next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.80.3):
+  next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.80.3):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -7787,6 +7817,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.6
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
+      '@playwright/test': 1.59.1
       sass: 1.80.3
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -8020,6 +8051,14 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.0.0: {}
 


### PR DESCRIPTION
## Summary
- Schedule word-clock text fitting through coalesced `requestAnimationFrame` work so resize events do not thrash layout.
- Prefer native `ResizeObserver`, keep the polyfill fallback, and avoid unchanged size updates.
- Refit when container width changes, after browser fonts finish loading, and at device-pixel-aware precision.
- Add metric-based Playwright coverage for resize refitting without screenshots.
- Avoid time-based hydration mismatches by rendering deterministic server output, then starting the live clock after hydration.
- Add `AGENTS.md` with PR authoring rules for future agent-authored changes.

## Why
The React package was relying on a resize path that could miss width-only changes and could produce different highlighted words between server render and client hydration. This PR captures the current behavior with focused unit/browser tests, fixes the resize and hydration edge cases, and documents how future agents should write reviewable PRs.

## Review Notes
- Start with `packages/wordclock-js/src/hooks/useResizeTextToFit.ts` for the fitting scheduler and binary-search changes.
- Then review `packages/wordclock-js/src/hooks/useSize.ts` for native `ResizeObserver` selection and unchanged-size handling.
- Review `packages/wordclock-js/src/hooks/useTimeProps.ts` and `packages/wordclock-js/src/components/WordClockContent.tsx` together for the hydration fix.
- Review `apps/example/e2e/word-clock-fit.spec.ts` for the browser behavior contract.
- `AGENTS.md` is intentionally agent-facing guidance, not a contributor template.

## Validation
- `pnpm --filter @simonheys/wordclock test`
- `pnpm --filter @simonheys/wordclock typecheck`
- `pnpm --filter @simonheys/wordclock lint`
- `pnpm --filter @simonheys/wordclock build`
- `pnpm --filter @simonheys/wordclock-example build`
- `pnpm --filter @simonheys/wordclock-example test:e2e`
- Manual example-app runtime check: no hydration error overlay.

## Risk
- Initial SSR output now renders words without time-based highlights; the live highlight state is applied immediately after hydration.
- The Playwright test is metric-based only. It intentionally does not assert exact visual styling or use screenshots.
