### PR TITLE
docs: refresh package readmes

### DIFF
--- a/apps/example/README.md
+++ b/apps/example/README.md
@@ -1,36 +1,32 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# WordClock Example
 
-## Getting Started
+Next.js app for exercising `@simonheys/wordclock` against the bundled word files in `@simonheys/wordclock-words`.
 
-First, run the development server:
+## For Consumers
+
+Use this app to inspect how the React package behaves with different language files and container heights. The page lets you:
+
+- mount and unmount the clock component
+- switch between word files from `@simonheys/wordclock-words`
+- test the text fitting behavior at several fixed heights
+
+The implementation lives in `src/app/page.tsx`.
+
+## For Contributors
+
+Run commands from the repository root:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+pnpm --filter @simonheys/wordclock-example dev
+pnpm --filter @simonheys/wordclock-example build
+pnpm --filter @simonheys/wordclock-example lint
+pnpm --filter @simonheys/wordclock-example test:e2e
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+The e2e test is metric-based. It verifies that the word clock stays within its container and refits when the container width changes; it does not use screenshots for visual regression testing.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+When changing the React package, rebuild it before relying on this app to verify package output:
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```bash
+pnpm --filter @simonheys/wordclock build
+```

--- a/packages/wordclock-js/README.md
+++ b/packages/wordclock-js/README.md
@@ -1,11 +1,62 @@
-# WordClock JS
+# WordClock React
 
-Simple react component that can run in a web browser
+React components for rendering a word clock in the browser.
 
-## Getting Started
+The package renders a supplied word definition, highlights the words that match the current time, and fits the text to the component container.
 
-Run the example development server from repository root
+## For Consumers
 
+Install the React package and the word definitions package:
+
+```bash
+pnpm add @simonheys/wordclock @simonheys/wordclock-words
 ```
-$ pnpm workspace wordclock-js start
+
+Render a clock with one of the bundled word files:
+
+```tsx
+import { WordClock, WordClockContent, type WordsJson } from '@simonheys/wordclock'
+import english from '@simonheys/wordclock-words/json/English_simple_fragmented.json'
+
+export function Clock() {
+  return (
+    <WordClock words={english as WordsJson}>
+      <WordClockContent />
+    </WordClock>
+  )
+}
 ```
+
+`WordClock` accepts normal `div` attributes and passes them to the rendered words container. This is useful for styling, labels, and test IDs.
+
+The package expects `react` and `react-dom` to be provided by the consuming app. Supported peer ranges are React 18 and React 19.
+
+## Word Files
+
+The `words` prop uses the `WordsJson` shape exported by this package. Each file contains:
+
+- `meta.language`: language code used by the manifest
+- `meta.title`: human-readable title for selectors and labels
+- `groups`: ordered rows of `item`, `sequence`, and `space` entries
+
+Use `@simonheys/wordclock-words` for the maintained set of bundled definitions.
+
+## For Contributors
+
+Run package commands from the repository root:
+
+```bash
+pnpm --filter @simonheys/wordclock test
+pnpm --filter @simonheys/wordclock typecheck
+pnpm --filter @simonheys/wordclock lint
+pnpm --filter @simonheys/wordclock build
+```
+
+To exercise the package in the example app:
+
+```bash
+pnpm --filter @simonheys/wordclock build
+pnpm --filter @simonheys/wordclock-example dev
+```
+
+The package build emits ESM, CommonJS, and TypeScript declaration files under `dist`.

--- a/packages/wordclock-words/README.md
+++ b/packages/wordclock-words/README.md
@@ -1,3 +1,65 @@
 # WordClock Words
 
-The words and expressions that influence how time is displayed in different variations or languages.
+Word definitions used by `@simonheys/wordclock` to describe time in different languages and styles.
+
+The package entry point is `json/Manifest.json`. Individual word files are published from the `json` directory.
+
+## For Consumers
+
+Import the manifest to list available word files:
+
+```ts
+import type { Manifest } from '@simonheys/wordclock'
+import manifest from '@simonheys/wordclock-words/json/Manifest.json'
+
+const files = (manifest as Manifest).files
+```
+
+Import a specific word file to render it with the React package:
+
+```tsx
+import { WordClock, WordClockContent, type WordsJson } from '@simonheys/wordclock'
+import english from '@simonheys/wordclock-words/json/English_simple_fragmented.json'
+
+export function Clock() {
+  return (
+    <WordClock words={english as WordsJson}>
+      <WordClockContent />
+    </WordClock>
+  )
+}
+```
+
+`Manifest.json` contains:
+
+- `files`: JSON files available in this package
+- `languages`: language-code to language-name mapping used for grouping selectors
+
+## Word File Shape
+
+Each word file contains:
+
+- `meta.language`: language code, such as `en`
+- `meta.title`: display title for the word file
+- `groups`: ordered groups of word definitions
+
+Group entries can be:
+
+- `item`: one or more explicit words with highlight expressions
+- `sequence`: generated words bound to `hour`, `minute`, or `second`
+- `space`: blank slots used to influence layout
+
+Highlight expressions are evaluated against time props such as `hour`, `twentyfourhour`, `minute`, `second`, `day`, `daystartingmonday`, `date`, and `month`.
+
+## For Contributors
+
+When adding or changing a word file:
+
+- add the JSON file under `json`
+- add the filename to `json/Manifest.json`
+- ensure `meta.language` exists in the manifest language map
+- run the validation tests
+
+```bash
+pnpm --filter @simonheys/wordclock-words test
+```


### PR DESCRIPTION
## Summary
- Replace the example app's generated Next.js README with WordClock-specific usage and contributor commands.
- Expand the React package README with consumer install/import guidance, word file expectations, and contributor checks.
- Expand the words package README with manifest usage, word file shape, and validation guidance.

## Why
The READMEs had drifted from the current workspace. The example app still described the create-next-app template, the React package documented a non-existent command, and the words package did not explain how consumers or contributors should use the bundled JSON definitions.

## Review Notes
- Review `apps/example/README.md` for the example-app workflow.
- Review `packages/wordclock-js/README.md` for npm consumer guidance and contributor commands.
- Review `packages/wordclock-words/README.md` for manifest and word-file documentation.

## Validation
- `pnpm --filter @simonheys/wordclock lint`
- `pnpm --filter @simonheys/wordclock-example lint`
- `pnpm --filter @simonheys/wordclock-words test`

## Risk
- Documentation-only change.
- Example lint still reports the existing `require()` import warnings in `src/app/page.tsx`; no new lint errors were introduced.
