### PR TITLE
Modernize TypeScript configuration

### DIFF
--- a/apps/example/next.config.mjs
+++ b/apps/example/next.config.mjs
@@ -5,6 +5,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  typedRoutes: true,
   turbopack: {
     root: resolve(__dirname, '../..'),
   },

--- a/apps/example/src/app/_lib/word-files.ts
+++ b/apps/example/src/app/_lib/word-files.ts
@@ -6,9 +6,21 @@ import { loadWordFile } from './load-word-file'
 
 const manifest = manifestJson as Manifest
 const preferredInitialFile = 'English_simple_fragmented.json'
-const initialFile = manifest.files.includes(preferredInitialFile)
-  ? preferredInitialFile
-  : manifest.files[0]
+
+const getInitialFile = () => {
+  if (manifest.files.includes(preferredInitialFile)) {
+    return preferredInitialFile
+  }
+
+  const [firstFile] = manifest.files
+  if (!firstFile) {
+    throw new Error('Word file manifest does not list any files')
+  }
+
+  return firstFile
+}
+
+const initialFile = getInitialFile()
 
 type LoadedWordFile = {
   file: string
@@ -32,21 +44,20 @@ const loadWordFileOption = async (file: string): Promise<LoadedWordFile> => {
 const groupWordFiles = (wordFiles: LoadedWordFile[]): WordFileGroup[] => {
   const groupsByLanguage = wordFiles.reduce<Record<string, WordFileGroup['options']>>(
     (groups, { file, languageTitle, title }) => {
-      if (!groups[languageTitle]) {
-        groups[languageTitle] = []
-      }
+      const options = groups[languageTitle] ?? []
+      groups[languageTitle] = options
 
-      groups[languageTitle].push({ file, title })
+      options.push({ file, title })
       return groups
     },
     {},
   )
 
-  return Object.keys(groupsByLanguage)
-    .sort()
-    .map((languageTitle) => ({
+  return Object.entries(groupsByLanguage)
+    .sort(([languageTitleA], [languageTitleB]) => languageTitleA.localeCompare(languageTitleB))
+    .map(([languageTitle, options]) => ({
       languageTitle,
-      options: groupsByLanguage[languageTitle],
+      options,
     }))
 }
 

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -1,14 +1,18 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "allowJs": true,
     "esModuleInterop": true,
+    "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
+    "moduleDetection": "force",
     "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "noUncheckedSideEffectImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strict": true
+    "strict": true,
+    "verbatimModuleSyntax": true
   }
 }

--- a/packages/typescript-config/nextjs.json
+++ b/packages/typescript-config/nextjs.json
@@ -3,6 +3,7 @@
   "extends": "./base.json",
   "compilerOptions": {
     "incremental": true,
+    "jsx": "preserve",
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
     "moduleResolution": "bundler",

--- a/packages/typescript-config/react-library.json
+++ b/packages/typescript-config/react-library.json
@@ -2,11 +2,9 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./base.json",
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
     "lib": ["dom", "dom.iterable", "esnext"],
-    "module": "esnext",
-    "moduleResolution": "node",
-    "noFallthroughCasesInSwitch": true,
+    "module": "preserve",
+    "moduleResolution": "bundler",
     "target": "ES2020"
   }
 }

--- a/packages/wordclock-js/src/components/WordClock.tsx
+++ b/packages/wordclock-js/src/components/WordClock.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { CSSProperties, FC, HTMLAttributes, useEffect, useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 
+import type { CSSProperties, FC, HTMLAttributes } from 'react'
 import { useResizeTextToFit } from '../hooks/useResizeTextToFit'
 import useTimeProps from '../hooks/useTimeProps'
 import * as WordsFileParser from '../modules/WordsFileParser'

--- a/packages/wordclock-js/src/components/WordClockContent.tsx
+++ b/packages/wordclock-js/src/components/WordClockContent.tsx
@@ -1,7 +1,8 @@
-import { FC } from 'react'
+import type { FC } from 'react'
 import * as LogicParser from '../modules/LogicParser'
 import { useWordClock } from './useWordClock'
-import { WordClockWord, WordClockWordProps } from './WordClockWord'
+import type { WordClockWordProps } from './WordClockWord'
+import { WordClockWord } from './WordClockWord'
 
 interface WordClockContentProps {
   wordComponent?: FC<WordClockWordProps>
@@ -14,15 +15,14 @@ export const WordClockContent: FC<WordClockContentProps> = ({
   return (
     <>
       {label.map((labelGroup, labelIndex) => {
-        const logicGroup = logic[labelIndex]
+        const logicGroup = logic[labelIndex] ?? []
         let hasPreviousHighlight = false
         let highlighted = false
         // only allow a single highlight per group
         return labelGroup.map((label, labelGroupIndex) => {
           highlighted = false
           if (timeProps && !hasPreviousHighlight) {
-            const logic = logicGroup[labelGroupIndex]
-            highlighted = LogicParser.term(logic, timeProps)
+            highlighted = LogicParser.term(logicGroup[labelGroupIndex] ?? '', timeProps)
             if (highlighted) {
               hasPreviousHighlight = true
             }

--- a/packages/wordclock-js/src/components/WordClockWord.tsx
+++ b/packages/wordclock-js/src/components/WordClockWord.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, FC, PropsWithChildren } from 'react'
+import type { CSSProperties, FC, PropsWithChildren } from 'react'
 
 export interface WordClockWordProps extends PropsWithChildren {
   highlighted: boolean

--- a/packages/wordclock-js/src/components/useWordClock.ts
+++ b/packages/wordclock-js/src/components/useWordClock.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext } from 'react'
-import { TimeProps } from '../hooks/useTimeProps'
-import { WordsLabel, WordsLogic } from './types'
+
+import type { TimeProps } from '../hooks/useTimeProps'
+import type { WordsLabel, WordsLogic } from './types'
 
 interface WordClockContentProps {
   logic: WordsLogic

--- a/packages/wordclock-js/src/modules/LogicParser.ts
+++ b/packages/wordclock-js/src/modules/LogicParser.ts
@@ -21,6 +21,17 @@ type ExtractArrayValues<T> = T extends readonly (infer U)[] ? U : never
 
 export type AllOperatorValues = ExtractArrayValues<Operators[OperatorKeys]>
 
+const getOperator = <Operator extends AllOperatorValues>(
+  operators: readonly Operator[],
+  index: number,
+): Operator => {
+  const operator = operators[index]
+  if (operator === undefined) {
+    throw new Error(`No operator found at index ${index}`)
+  }
+  return operator
+}
+
 // ____________________________________________________________________________________________________ term
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -49,14 +60,15 @@ export const term = (source: string, props?: Props) => {
         array: OPERATORS.MATH,
       })
       if (result !== -1) {
+        const operator = getOperator(OPERATORS.MATH, result)
         terms = LogicParserStringUtil.extractTermsAroundPivot({
           source,
-          pivot: OPERATORS.MATH[result],
+          pivot: operator,
         })
         const operationResult = performOperation({
           termOne: terms[1],
           termTwo: terms[2],
-          operator: OPERATORS.MATH[result],
+          operator,
           props,
         })
         source = `${terms[0]}${operationResult}${terms[3]}`
@@ -67,14 +79,15 @@ export const term = (source: string, props?: Props) => {
           array: OPERATORS.EQUALITY,
         })
         if (result !== -1) {
+          const operator = getOperator(OPERATORS.EQUALITY, result)
           terms = LogicParserStringUtil.extractTermsAroundPivot({
             source,
-            pivot: OPERATORS.EQUALITY[result],
+            pivot: operator,
           })
           const operationResult = performOperation({
             termOne: terms[1],
             termTwo: terms[2],
-            operator: OPERATORS.EQUALITY[result],
+            operator,
             props,
           })
           source = `${terms[0]}${operationResult}${terms[3]}`
@@ -85,14 +98,15 @@ export const term = (source: string, props?: Props) => {
             array: OPERATORS.BOOLEAN,
           })
           if (result !== -1) {
+            const operator = getOperator(OPERATORS.BOOLEAN, result)
             terms = LogicParserStringUtil.extractTermsAroundPivot({
               source,
-              pivot: OPERATORS.BOOLEAN[result],
+              pivot: operator,
             })
             const operationResult = performOperation({
               termOne: terms[1],
               termTwo: terms[2],
-              operator: OPERATORS.BOOLEAN[result],
+              operator,
               props,
             })
             source = `${terms[0]}${operationResult}${terms[3]}`
@@ -153,7 +167,7 @@ export const performOperation = ({
   termOne?: string
   termTwo?: string
   operator?: AllOperatorValues
-  props?: Props
+  props?: Props | undefined
 } = {}) => {
   // replace variable names where appropriate
   const a = processTerm(termOne, props)

--- a/packages/wordclock-js/src/modules/LogicParserStringUtil.test.ts
+++ b/packages/wordclock-js/src/modules/LogicParserStringUtil.test.ts
@@ -33,7 +33,6 @@ describe('LogicParserStringUtil', () => {
     })
     describe('when invalid', () => {
       it('returns an empty string', () => {
-        // @ts-expect-error testing invalid input
         expect(extractStringContainedInOutermostBraces()).toEqual('')
       })
     })

--- a/packages/wordclock-js/src/modules/LogicParserStringUtil.ts
+++ b/packages/wordclock-js/src/modules/LogicParserStringUtil.ts
@@ -4,16 +4,26 @@ const objectToString = Object.prototype.toString
 const isString = (value: unknown): value is string =>
   typeof value === 'string' || objectToString.call(value) === '[object String]'
 
+type BraceTerms = [leftOfBraces: string, insideBraces: string, rightOfBraces: string]
+type PivotTerms = [
+  beforeLeftTerm: string,
+  leftTerm: string,
+  rightTerm: string,
+  afterRightTerm: string,
+]
+
 export const isNumericString = (string: string) => {
   return /^-?\d+$/.test(string)
 }
 
-export const extractStringContainedInOutermostBraces = (source: string) => {
+export function extractStringContainedInOutermostBraces(source: string): BraceTerms
+export function extractStringContainedInOutermostBraces(source?: string): BraceTerms | ''
+export function extractStringContainedInOutermostBraces(source?: string): BraceTerms | '' {
   if (!isString(source)) {
     return ''
   }
 
-  let rightOfBraces
+  let rightOfBraces: string
   let count
   let i
   let c
@@ -54,19 +64,20 @@ export const scanForInstanceOf = ({
   if (!isString(source) || !Array.isArray(array)) {
     return -1
   }
-  for (let i = 0; i < array.length; i++) {
-    if (source.indexOf(array[i]) !== -1) {
-      return i
-    }
-  }
-  return -1
+  return array.findIndex((instance) => source.indexOf(instance) !== -1)
 }
 
-export const extractTermsAroundPivot = ({ source, pivot }: { source: string; pivot: string }) => {
-  let leftTerm
-  let rightTerm
-  let beforeLeftTerm
-  let afterRightTerm
+export const extractTermsAroundPivot = ({
+  source,
+  pivot,
+}: {
+  source: string
+  pivot: string
+}): PivotTerms => {
+  let leftTerm: string
+  let rightTerm: string
+  let beforeLeftTerm: string
+  let afterRightTerm: string
   let c
   let i
 

--- a/packages/wordclock-js/src/modules/WordsFileParser.test.ts
+++ b/packages/wordclock-js/src/modules/WordsFileParser.test.ts
@@ -75,9 +75,14 @@ describe('WordsFileParser', () => {
       'hour==11',
       'hour==12',
     ])
-    expect(label[3]).toHaveLength(60)
-    expect(logic[3]).toHaveLength(60)
-    expect(label[3][1]).toBe('and')
-    expect(logic[3][1]).toBe('second!=0')
+    const minuteLabels = label[3]
+    const minuteLogic = logic[3]
+    if (!minuteLabels || !minuteLogic) {
+      throw new Error('Expected parsed minute groups')
+    }
+    expect(minuteLabels).toHaveLength(60)
+    expect(minuteLogic).toHaveLength(60)
+    expect(minuteLabels[1]).toBe('and')
+    expect(minuteLogic[1]).toBe('second!=0')
   })
 })


### PR DESCRIPTION
## Summary
- tighten the shared TypeScript baseline with verbatim module syntax, checked side-effect imports, stricter optional/indexed access, and forced module detection
- align package configs with their runtimes: bundler-style module handling for the React/Vite package and preserved JSX for Next
- enable stable typed routes in the example Next app
- update affected code with type-only imports and explicit guards for parser and word-file lookups

## Why
This follows up on the tooling cleanup by making the shared TypeScript package a stronger default for current TypeScript and Next usage. The stricter settings expose assumptions around array/object indexing and module import intent before they can become runtime issues.

## Review Notes
Start with packages/typescript-config/* to see the policy change. The React package and example app edits are the direct fallout from those stricter compiler options.

## Validation
- pnpm format:check
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm test

## Risk
The main risk is stricter compiler behavior for future code. Existing runtime behavior is covered by the current unit tests, including the parser helper invalid-input case that this change preserves.