### PR TITLE
Fix LogicParser edge cases

### DIFF
--- a/packages/wordclock-js/src/modules/LogicParser.test.ts
+++ b/packages/wordclock-js/src/modules/LogicParser.test.ts
@@ -1,5 +1,3 @@
-/// <reference types="vite/client" />
-
 import type { WordsJson } from '../components/types'
 import { performOperation, processTerm, term } from './LogicParser'
 import { parseJson } from './WordsFileParser'

--- a/packages/wordclock-js/src/modules/LogicParser.test.ts
+++ b/packages/wordclock-js/src/modules/LogicParser.test.ts
@@ -60,6 +60,19 @@ describe('LogicParser', () => {
           expect(term('(27*3+(5+10))%(7*2)')).toEqual(12)
         })
       })
+      describe('when using unary operators', () => {
+        it('returns the expected result', () => {
+          expect(term('-2')).toEqual(-2)
+          expect(term('--2')).toEqual(2)
+          expect(term('-2*3')).toEqual(-6)
+          expect(term('2*-3')).toEqual(-6)
+          expect(term('-2-3')).toEqual(-5)
+          expect(term('2--3')).toEqual(5)
+          expect(term('2 - -3')).toEqual(5)
+          expect(term('!false')).toEqual(true)
+          expect(term('2*!false')).toEqual(2)
+        })
+      })
       describe('when using numbers and props', () => {
         it('returns the expected result', () => {
           const props = {
@@ -86,6 +99,13 @@ describe('LogicParser', () => {
           expect(term('(second%10)==2 && !(second>10 && second<21)', { second: 2 })).toEqual(true)
           expect(term('(second%10)==2 && !(second>10 && second<21)', { second: 12 })).toEqual(false)
           expect(term('(second%10)==2 && !(second>10 && second<21)', { second: 22 })).toEqual(true)
+        })
+      })
+      describe('when braces are malformed', () => {
+        it('leaves the malformed term intact', () => {
+          expect(term('(true')).toEqual('(true')
+          expect(term('true)')).toEqual('true)')
+          expect(term(')(')).toEqual(')(')
         })
       })
     })

--- a/packages/wordclock-js/src/modules/LogicParser.test.ts
+++ b/packages/wordclock-js/src/modules/LogicParser.test.ts
@@ -1,4 +1,76 @@
+/// <reference types="vite/client" />
+
+import type { WordsJson } from '../components/types'
 import { performOperation, processTerm, term } from './LogicParser'
+import { parseJson } from './WordsFileParser'
+
+const wordFileModules = import.meta.glob<{ default: WordsJson }>(
+  '../../../wordclock-words/json/*.json',
+  { eager: true },
+)
+const timePropNames = [
+  'date',
+  'day',
+  'daystartingmonday',
+  'hour',
+  'minute',
+  'month',
+  'second',
+  'twentyfourhour',
+] as const
+const timeValues = [
+  0, 1, 2, 3, 4, 5, 10, 11, 12, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 29, 30, 31, 39, 40,
+  41, 47, 49, 50, 51, 52, 55, 56, 57, 58, 59,
+]
+const javaScriptExpressionPattern = /^[\s!%&*()+\-/<>=|A-Za-z0-9_]+$/
+
+type TimePropName = (typeof timePropNames)[number]
+type TimeProps = Record<TimePropName, number>
+
+const createTimeProps = (value: number): TimeProps => ({
+  date: value,
+  day: value % 7,
+  daystartingmonday: value % 7,
+  hour: value % 12 || 12,
+  minute: value % 60,
+  month: (value % 12) + 1,
+  second: value % 60,
+  twentyfourhour: value % 24,
+})
+
+const getWordFileExpressions = () => {
+  const expressions = new Set<string>()
+
+  for (const [file, module] of Object.entries(wordFileModules)) {
+    if (file.endsWith('/Manifest.json')) {
+      continue
+    }
+
+    const { logic } = parseJson(module.default)
+
+    for (const logicGroup of logic) {
+      for (const expression of logicGroup) {
+        const trimmedExpression = expression.trim()
+        if (trimmedExpression) {
+          expressions.add(trimmedExpression)
+        }
+      }
+    }
+  }
+
+  return [...expressions].sort()
+}
+
+const createJavaScriptEvaluator = (expression: string) => {
+  const javaScriptExpression = expression.replace(/\belse\b/g, 'true')
+  if (!javaScriptExpressionPattern.test(javaScriptExpression)) {
+    throw new Error(`Unexpected expression characters: ${expression}`)
+  }
+
+  return Function(...timePropNames, `return (${javaScriptExpression})`) as (
+    ...values: number[]
+  ) => unknown
+}
 
 describe('LogicParser', () => {
   describe('processTerm', () => {
@@ -114,6 +186,27 @@ describe('LogicParser', () => {
         // @ts-expect-error testing invalid input
         expect(term()).toEqual('')
       })
+    })
+  })
+
+  describe('word file expressions', () => {
+    it('matches JavaScript evaluation for the checked-in word files', () => {
+      const expressions = getWordFileExpressions()
+      const samples = timeValues.map(createTimeProps)
+
+      expect(expressions).toHaveLength(470)
+      expect(samples).toHaveLength(37)
+
+      for (const expression of expressions) {
+        const evaluateWithJavaScript = createJavaScriptEvaluator(expression)
+
+        for (const props of samples) {
+          const expected = evaluateWithJavaScript(...timePropNames.map((name) => props[name]))
+          const actual = term(expression, props)
+
+          expect(actual, `${expression} with ${JSON.stringify(props)}`).toEqual(expected)
+        }
+      }
     })
   })
 })

--- a/packages/wordclock-js/src/modules/LogicParser.ts
+++ b/packages/wordclock-js/src/modules/LogicParser.ts
@@ -49,7 +49,7 @@ export const term = (source: string, props?: Props) => {
   parsing = true
   while (parsing) {
     // parse brackets
-    if (LogicParserStringUtil.containsBraces(source)) {
+    if (LogicParserStringUtil.checkBalancedBraces(source)) {
       terms = LogicParserStringUtil.extractStringContainedInOutermostBraces(source)
       const termResult = term(terms[1], props)
       source = `${terms[0]}${termResult}${terms[2]}`

--- a/packages/wordclock-js/src/modules/LogicParserStringUtil.test.ts
+++ b/packages/wordclock-js/src/modules/LogicParserStringUtil.test.ts
@@ -32,8 +32,9 @@ describe('LogicParserStringUtil', () => {
       })
     })
     describe('when invalid', () => {
-      it('returns an empty string', () => {
-        expect(extractStringContainedInOutermostBraces()).toEqual('')
+      it('throws an error', () => {
+        // @ts-expect-error testing invalid input
+        expect(() => extractStringContainedInOutermostBraces()).toThrow()
       })
     })
   })

--- a/packages/wordclock-js/src/modules/LogicParserStringUtil.test.ts
+++ b/packages/wordclock-js/src/modules/LogicParserStringUtil.test.ts
@@ -50,6 +50,26 @@ describe('LogicParserStringUtil', () => {
         expect(rightTerm).toEqual('25')
         expect(afterRightTerm).toEqual('+6')
       })
+      it('keeps unary operators attached to their terms', () => {
+        expect(
+          extractTermsAroundPivot({
+            source: '-2*3',
+            pivot: '*',
+          }),
+        ).toEqual(['', '-2', '3', ''])
+        expect(
+          extractTermsAroundPivot({
+            source: '2*-3+4',
+            pivot: '*',
+          }),
+        ).toEqual(['', '2', '-3', '+4'])
+        expect(
+          extractTermsAroundPivot({
+            source: '2 - -3',
+            pivot: '-',
+          }),
+        ).toEqual(['', '2 ', ' -3', ''])
+      })
     })
     describe('when invalid', () => {
       it('throws an error', () => {
@@ -93,6 +113,11 @@ describe('LogicParserStringUtil', () => {
           expect(checkBalancedBraces('(((foo))')).toBeFalsy()
         })
       })
+      describe('when braces close before they open', () => {
+        it('returns false', () => {
+          expect(checkBalancedBraces(')foo(')).toBeFalsy()
+        })
+      })
     })
     describe('when invalid', () => {
       it('return false', () => {
@@ -106,6 +131,11 @@ describe('LogicParserStringUtil', () => {
     describe('when array contains instance', () => {
       it('returns the index of the instance in the array', () => {
         expect(scanForInstanceOf({ source: 'foo=bar', array: ['*', '='] })).toEqual(1)
+      })
+      it('ignores unary minus when scanning for binary operators', () => {
+        expect(scanForInstanceOf({ source: '-2', array: ['-'] })).toEqual(-1)
+        expect(scanForInstanceOf({ source: '-2-3', array: ['-'] })).toEqual(0)
+        expect(scanForInstanceOf({ source: '2*-3', array: ['*', '-'] })).toEqual(0)
       })
     })
     describe('when array does not contains instance', () => {

--- a/packages/wordclock-js/src/modules/LogicParserStringUtil.ts
+++ b/packages/wordclock-js/src/modules/LogicParserStringUtil.ts
@@ -16,6 +16,36 @@ export const isNumericString = (string: string) => {
   return /^-?\d+$/.test(string)
 }
 
+const isUnaryMinus = (source: string, index: number) => {
+  if (source.charAt(index) !== '-') {
+    return false
+  }
+
+  const previous = source.slice(0, index).trimEnd().at(-1)
+  return previous === undefined || (previous !== ')' && OPERATORS.indexOf(previous) !== -1)
+}
+
+const isUnaryRightTermOperator = (source: string, index: number) => {
+  const character = source.charAt(index)
+  if (character !== '-' && character !== '!') {
+    return false
+  }
+
+  return source.slice(0, index).trim() === ''
+}
+
+const getOperatorIndex = (source: string, operator: string) => {
+  let index = source.indexOf(operator)
+  while (index !== -1) {
+    if (operator !== '-' || !isUnaryMinus(source, index)) {
+      return index
+    }
+    index = source.indexOf(operator, index + operator.length)
+  }
+
+  return -1
+}
+
 export function extractStringContainedInOutermostBraces(source: string): BraceTerms
 export function extractStringContainedInOutermostBraces(source?: string): BraceTerms | ''
 export function extractStringContainedInOutermostBraces(source?: string): BraceTerms | '' {
@@ -64,7 +94,7 @@ export const scanForInstanceOf = ({
   if (!isString(source) || !Array.isArray(array)) {
     return -1
   }
-  return array.findIndex((instance) => source.indexOf(instance) !== -1)
+  return array.findIndex((instance) => getOperatorIndex(source, instance) !== -1)
 }
 
 export const extractTermsAroundPivot = ({
@@ -81,7 +111,7 @@ export const extractTermsAroundPivot = ({
   let c
   let i
 
-  const pivotLocation = source.indexOf(pivot)
+  const pivotLocation = getOperatorIndex(source, pivot)
 
   const leftOfPivot = source.substr(0, pivotLocation)
   const rightOfPivot = source.substr(pivotLocation + pivot.length)
@@ -96,7 +126,10 @@ export const extractTermsAroundPivot = ({
     c = leftOfPivot.substr(i, 1)
   }
 
-  if (OPERATORS.indexOf(c) !== -1) {
+  if (c === '-' && isUnaryMinus(leftOfPivot, i)) {
+    leftTerm = leftOfPivot.substr(i)
+    beforeLeftTerm = leftOfPivot.substr(0, i)
+  } else if (OPERATORS.indexOf(c) !== -1) {
     leftTerm = leftOfPivot.substr(i + 1)
     beforeLeftTerm = leftOfPivot.substr(0, i + 1)
   } else {
@@ -110,7 +143,10 @@ export const extractTermsAroundPivot = ({
     i = 0
     c = rightOfPivot.substr(i, 1)
 
-    while (i < rightOfPivot.length && OPERATORS.indexOf(c) === -1) {
+    while (
+      i < rightOfPivot.length &&
+      (OPERATORS.indexOf(c) === -1 || isUnaryRightTermOperator(rightOfPivot, i))
+    ) {
       i++
       if (i < rightOfPivot.length) {
         c = rightOfPivot.substr(i, 1)
@@ -154,9 +190,22 @@ export const checkBalancedBraces = (source: string) => {
   if (!containsBraces(source)) {
     return false
   }
-  const leftInstances = countInstancesOf({ source, instance: '(' })
-  const rightInstances = countInstancesOf({ source, instance: ')' })
-  return leftInstances === rightInstances
+
+  let depth = 0
+  for (let i = 0; i < source.length; i++) {
+    const character = source.substr(i, 1)
+    if (character === '(') {
+      depth++
+    }
+    if (character === ')') {
+      depth--
+    }
+    if (depth < 0) {
+      return false
+    }
+  }
+
+  return depth === 0
 }
 
 export const contains = ({

--- a/packages/wordclock-js/src/modules/LogicParserStringUtil.ts
+++ b/packages/wordclock-js/src/modules/LogicParserStringUtil.ts
@@ -46,13 +46,7 @@ const getOperatorIndex = (source: string, operator: string) => {
   return -1
 }
 
-export function extractStringContainedInOutermostBraces(source: string): BraceTerms
-export function extractStringContainedInOutermostBraces(source?: string): BraceTerms | ''
-export function extractStringContainedInOutermostBraces(source?: string): BraceTerms | '' {
-  if (!isString(source)) {
-    return ''
-  }
-
+export const extractStringContainedInOutermostBraces = (source: string): BraceTerms => {
   let rightOfBraces: string
   let count
   let i

--- a/packages/wordclock-js/tsconfig.json
+++ b/packages/wordclock-js/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@simonheys/typescript-config/react-library.json",
   "compilerOptions": {
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- keep LogicParser hand-written while tightening scanner behavior around unary minus and prefix negation
- avoid treating malformed parentheses as parseable bracket groups, preserving invalid terms instead of eating characters
- simplify the brace extractor to a single internal string-to-tuple signature instead of TypeScript overloads
- add focused tests for signed terms, unary operator extraction, malformed braces, and brace ordering
- add a checked-in word-file conformance test that compares LogicParser.term against JavaScript evaluation for the production JSON expression corpus

## Why
The parser already supports unary handling in processTerm, but the operator scanner could see a leading minus as binary math. That made expressions like -2 unsafe and expressions like 2*-3 parse incorrectly. Malformed braces could also be partially consumed before the parser fell back to term processing.

## Review Notes
Start with packages/wordclock-js/src/modules/LogicParserStringUtil.ts. The production change stays in the existing scanner/extractor style; LogicParser.ts only switches bracket parsing to the existing balanced-brace predicate.

The JavaScript evaluator is test-only. It uses Vite glob imports over the checked-in word JSON files, replaces the parser-only else token with true, and rejects unexpected expression characters before constructing the evaluator.

## Validation
- pnpm format:check
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm test
- parser conformance test: 470 generated word-file expressions across 37 representative samples

## Risk
Low for current word files: the conformance test covers all generated checked-in word-file expressions. The intended behavior change is limited to previously unsafe malformed or unary expressions.