### PR TITLE
Harden GitHub Actions checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Lint
 
 on:
+  push:
+    branches:
+      - main
+      - develop
   pull_request:
     branches:
       - main

--- a/.github/workflows/publish-wordclock-js.yml
+++ b/.github/workflows/publish-wordclock-js.yml
@@ -43,8 +43,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Lint package
+        run: pnpm --filter @simonheys/wordclock lint
+
+      - name: Typecheck package
+        run: pnpm --filter @simonheys/wordclock typecheck
+
+      - name: Test package
+        run: pnpm --filter @simonheys/wordclock test
+
       - name: Build package
-        run: cd packages/wordclock-js && pnpm build
+        run: pnpm --filter @simonheys/wordclock build
 
       - name: Publish
         env:

--- a/.github/workflows/publish-wordclock-words.yml
+++ b/.github/workflows/publish-wordclock-words.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Test package
+        run: pnpm --filter @simonheys/wordclock-words test
+
       - name: Publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
 
 on:
+  push:
+    branches:
+      - main
+      - develop
   pull_request:
     branches:
       - main
@@ -28,3 +32,22 @@ jobs:
         run: pnpm build
       - name: Test
         run: pnpm test
+
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+      - name: Use Node.js lts/*
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright
+        run: pnpm --filter @simonheys/wordclock-example exec playwright install --with-deps chromium
+      - name: Run e2e tests
+        run: pnpm --filter @simonheys/wordclock-example test:e2e


### PR DESCRIPTION
## Summary
- run lint/typecheck/format and test workflows on pushes to `main`/`develop` as well as PRs
- add an example app Playwright e2e job to the PR/push test workflow
- run package validation before semantic-release publish jobs

## Why
CI existed for PRs, but direct pushes were under-covered and branch protection was not requiring concrete checks. This makes the workflow surface match the repo scripts and catches format, lint, type, build, unit, and e2e issues.

## Review Notes
The e2e job uses the existing example app Playwright config, including its webServer setup. Publish jobs still publish only from package-specific release workflows, but now validate package-specific lint/type/test/build where available.

## Validation
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |file| YAML.load_file(file) }'`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm --filter @simonheys/wordclock-example test:e2e`