### PR TITLE
fix(macos): draw highlighted words in front again

### DIFF
--- a/packages/wordclock-macos/WordClockCoreMac/WordClockMetalRenderer.h
+++ b/packages/wordclock-macos/WordClockCoreMac/WordClockMetalRenderer.h
@@ -11,7 +11,7 @@
 @interface WordClockMetalRenderer : NSObject <MTKViewDelegate>
 
 - (instancetype)initWithView:(MTKView *)view;
-- (void)updateWordVertices:(const float *)positions colors:(const float *)colors texCoords:(const short *)texCoords wordCount:(NSUInteger)wordCount scale:(float)scale;
+- (void)updateWordVertices:(const float *)positions colors:(const float *)colors texCoords:(const short *)texCoords highlighted:(const BOOL *)highlighted wordCount:(NSUInteger)wordCount scale:(float)scale;
 - (void)updateWordTextures:(NSArray<id<MTLTexture>> *)textures;
 - (void)updateGuideVertices:(const float *)positions colors:(const float *)colors count:(NSUInteger)count;
 

--- a/packages/wordclock-macos/WordClockCoreMac/WordClockMetalRenderer.m
+++ b/packages/wordclock-macos/WordClockCoreMac/WordClockMetalRenderer.m
@@ -53,6 +53,7 @@ static matrix_float4x4 WordClockOrtho(CGFloat left, CGFloat right, CGFloat botto
     NSMutableArray<id<MTLTexture>> *_wordTextures;
     BOOL *_wordHighlighted;
     NSUInteger _wordHighlightedCapacity;
+    NSLock *_renderStateLock;
     MTKView *_view;
 }
 @end
@@ -127,6 +128,7 @@ static matrix_float4x4 WordClockOrtho(CGFloat left, CGFloat right, CGFloat botto
         _quadVertexBuffer = [self buildQuad];
         _uniformBuffer = [_device newBufferWithLength:sizeof(VSUniforms) options:MTLResourceStorageModeShared];
         _wordTextures = [[NSMutableArray alloc] init];
+        _renderStateLock = [[NSLock alloc] init];
         MTLSamplerDescriptor *samplerDesc = [[[MTLSamplerDescriptor alloc] init] autorelease];
         samplerDesc.minFilter = MTLSamplerMinMagFilterLinear;
         samplerDesc.magFilter = MTLSamplerMinMagFilterLinear;
@@ -155,6 +157,7 @@ static matrix_float4x4 WordClockOrtho(CGFloat left, CGFloat right, CGFloat botto
     [_guideVertexBuffer release];
     [_wordTextures release];
     free(_wordHighlighted);
+    [_renderStateLock release];
     [_samplerState release];
     [_opaqueTexture release];
     [_transparentTexture release];
@@ -221,8 +224,10 @@ static matrix_float4x4 WordClockOrtho(CGFloat left, CGFloat right, CGFloat botto
 - (void)mtkView:(MTKView *)view drawableSizeWillChange:(CGSize)size {
     (void)view;
     (void)size;
+    [_renderStateLock lock];
     [self updateUniformsForSize:view.bounds.size];
     [self updateQuadForSize:view.bounds.size];
+    [_renderStateLock unlock];
 }
 
 - (void)drawInMTKView:(MTKView *)view {
@@ -237,6 +242,7 @@ static matrix_float4x4 WordClockOrtho(CGFloat left, CGFloat right, CGFloat botto
         return;
     }
     id<MTLRenderCommandEncoder> encoder = [commandBuffer renderCommandEncoderWithDescriptor:pass];
+    [_renderStateLock lock];
     if (_pipelineState) {
         [encoder setRenderPipelineState:_pipelineState];
         if (_wordVertexBuffer && _wordVertexCount > 0) {
@@ -288,15 +294,18 @@ static matrix_float4x4 WordClockOrtho(CGFloat left, CGFloat right, CGFloat botto
             [encoder drawPrimitives:MTLPrimitiveTypeLine vertexStart:0 vertexCount:_guideVertexCount];
         }
     }
+    [_renderStateLock unlock];
     [encoder endEncoding];
     [commandBuffer presentDrawable:drawable];
     [commandBuffer commit];
 }
 
 - (void)updateWordVertices:(const float *)positions colors:(const float *)colors texCoords:(const short *)texCoords highlighted:(const BOOL *)highlighted wordCount:(NSUInteger)wordCount scale:(float)scale {
+    [_renderStateLock lock];
     if (!positions || !colors || wordCount == 0) {
         _wordVertexCount = 0;
         _wordCount = 0;
+        [_renderStateLock unlock];
         return;
     }
 
@@ -363,16 +372,21 @@ static matrix_float4x4 WordClockOrtho(CGFloat left, CGFloat right, CGFloat botto
         outVertices[base + 4] = (WordVertex){.position = {x1, y1}, .uv = {u1, v1}, .color = c1};
         outVertices[base + 5] = (WordVertex){.position = {x3, y3}, .uv = {u3, v3}, .color = c3};
     }
+    [_renderStateLock unlock];
 }
 
 - (void)updateWordTextures:(NSArray<id<MTLTexture>> *)textures {
+    [_renderStateLock lock];
     [_wordTextures release];
     _wordTextures = [textures mutableCopy];
+    [_renderStateLock unlock];
 }
 
 - (void)updateGuideVertices:(const float *)positions colors:(const float *)colors count:(NSUInteger)count {
+    [_renderStateLock lock];
     if (!positions || !colors || count == 0) {
         _guideVertexCount = 0;
+        [_renderStateLock unlock];
         return;
     }
     const NSUInteger bufferLength = count * sizeof(WordVertex);
@@ -395,6 +409,7 @@ static matrix_float4x4 WordClockOrtho(CGFloat left, CGFloat right, CGFloat botto
         };
     }
     _guideVertexCount = count;
+    [_renderStateLock unlock];
 }
 
 @end

--- a/packages/wordclock-macos/WordClockCoreMac/WordClockMetalRenderer.m
+++ b/packages/wordclock-macos/WordClockCoreMac/WordClockMetalRenderer.m
@@ -51,6 +51,8 @@ static matrix_float4x4 WordClockOrtho(CGFloat left, CGFloat right, CGFloat botto
     id<MTLTexture> _opaqueTexture;
     id<MTLTexture> _transparentTexture;
     NSMutableArray<id<MTLTexture>> *_wordTextures;
+    BOOL *_wordHighlighted;
+    NSUInteger _wordHighlightedCapacity;
     MTKView *_view;
 }
 @end
@@ -152,6 +154,7 @@ static matrix_float4x4 WordClockOrtho(CGFloat left, CGFloat right, CGFloat botto
     [_wordVertexBuffer release];
     [_guideVertexBuffer release];
     [_wordTextures release];
+    free(_wordHighlighted);
     [_samplerState release];
     [_opaqueTexture release];
     [_transparentTexture release];
@@ -246,19 +249,34 @@ static matrix_float4x4 WordClockOrtho(CGFloat left, CGFloat right, CGFloat botto
             [encoder setFragmentSamplerState:_samplerState atIndex:0];
         }
         if (_wordVertexBuffer && _wordVertexCount > 0) {
-            for (NSUInteger i = 0; i < _wordCount; i++) {
-                id<MTLTexture> texture = nil;
-                if (i < [_wordTextures count]) {
-                    id candidate = [_wordTextures objectAtIndex:i];
-                    if (candidate != [NSNull null]) {
-                        texture = candidate;
+            // Two passes so highlighted words are never occluded by the
+            // unhighlighted ones, which overlap heavily in the rotary layout.
+            // The pre-Metal renderer did the same by deferring highlighted
+            // indices to a second glDrawArrays loop.
+            const BOOL *highlighted = (_wordHighlightedCapacity >= _wordCount) ? _wordHighlighted : NULL;
+            for (int pass = 0; pass < 2; pass++) {
+                const BOOL drawingHighlighted = (pass == 1);
+                if (drawingHighlighted && !highlighted) {
+                    break;  // nothing was deferred, everything drew in pass 0
+                }
+                for (NSUInteger i = 0; i < _wordCount; i++) {
+                    const BOOL wordIsHighlighted = highlighted ? highlighted[i] : NO;
+                    if (wordIsHighlighted != drawingHighlighted) {
+                        continue;
                     }
+                    id<MTLTexture> texture = nil;
+                    if (i < [_wordTextures count]) {
+                        id candidate = [_wordTextures objectAtIndex:i];
+                        if (candidate != [NSNull null]) {
+                            texture = candidate;
+                        }
+                    }
+                    if (!texture) {
+                        texture = _transparentTexture;
+                    }
+                    [encoder setFragmentTexture:texture atIndex:0];
+                    [encoder drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:(NSUInteger)(i * 6) vertexCount:6];
                 }
-                if (!texture) {
-                    texture = _transparentTexture;
-                }
-                [encoder setFragmentTexture:texture atIndex:0];
-                [encoder drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:(NSUInteger)(i * 6) vertexCount:6];
             }
         } else {
             [encoder setFragmentTexture:_opaqueTexture atIndex:0];
@@ -275,11 +293,28 @@ static matrix_float4x4 WordClockOrtho(CGFloat left, CGFloat right, CGFloat botto
     [commandBuffer commit];
 }
 
-- (void)updateWordVertices:(const float *)positions colors:(const float *)colors texCoords:(const short *)texCoords wordCount:(NSUInteger)wordCount scale:(float)scale {
+- (void)updateWordVertices:(const float *)positions colors:(const float *)colors texCoords:(const short *)texCoords highlighted:(const BOOL *)highlighted wordCount:(NSUInteger)wordCount scale:(float)scale {
     if (!positions || !colors || wordCount == 0) {
         _wordVertexCount = 0;
         _wordCount = 0;
         return;
+    }
+
+    // Kept alongside the vertices so the draw order can never use flags from a
+    // different word count than the geometry.
+    if (_wordHighlightedCapacity < wordCount) {
+        BOOL *resized = realloc(_wordHighlighted, wordCount * sizeof(BOOL));
+        if (resized) {
+            _wordHighlighted = resized;
+            _wordHighlightedCapacity = wordCount;
+        }
+    }
+    if (_wordHighlighted && _wordHighlightedCapacity >= wordCount) {
+        if (highlighted) {
+            memcpy(_wordHighlighted, highlighted, wordCount * sizeof(BOOL));
+        } else {
+            memset(_wordHighlighted, 0, wordCount * sizeof(BOOL));
+        }
     }
     const NSUInteger vertexCount = wordCount * 6;
     const NSUInteger bufferLength = vertexCount * sizeof(WordVertex);

--- a/packages/wordclock-macos/WordClockCoreMac/WordClockMetalView.h
+++ b/packages/wordclock-macos/WordClockCoreMac/WordClockMetalView.h
@@ -13,7 +13,7 @@
 @property(nonatomic, assign) BOOL tracksMouseEvents;
 
 - (instancetype)initWithFrame:(NSRect)frameRect;
-- (void)updateWordVertices:(const float *)positions colors:(const float *)colors texCoords:(const short *)texCoords wordCount:(NSUInteger)wordCount scale:(float)scale;
+- (void)updateWordVertices:(const float *)positions colors:(const float *)colors texCoords:(const short *)texCoords highlighted:(const BOOL *)highlighted wordCount:(NSUInteger)wordCount scale:(float)scale;
 - (void)updateWordTextures:(NSArray<id<MTLTexture>> *)textures;
 - (void)updateGuideVertices:(const float *)positions colors:(const float *)colors count:(NSUInteger)count;
 

--- a/packages/wordclock-macos/WordClockCoreMac/WordClockMetalView.m
+++ b/packages/wordclock-macos/WordClockCoreMac/WordClockMetalView.m
@@ -45,8 +45,8 @@
     [super dealloc];
 }
 
-- (void)updateWordVertices:(const float *)positions colors:(const float *)colors texCoords:(const short *)texCoords wordCount:(NSUInteger)wordCount scale:(float)scale {
-    [_renderer updateWordVertices:positions colors:colors texCoords:texCoords wordCount:wordCount scale:scale];
+- (void)updateWordVertices:(const float *)positions colors:(const float *)colors texCoords:(const short *)texCoords highlighted:(const BOOL *)highlighted wordCount:(NSUInteger)wordCount scale:(float)scale {
+    [_renderer updateWordVertices:positions colors:colors texCoords:texCoords highlighted:highlighted wordCount:wordCount scale:scale];
 }
 
 - (void)updateWordTextures:(NSArray<id<MTLTexture>> *)textures {

--- a/packages/wordclock-macos/WordClockRenderView.m
+++ b/packages/wordclock-macos/WordClockRenderView.m
@@ -453,7 +453,7 @@ static CVReturn MyDisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTime
         if (self.controller.scene) {
             sceneScale = self.controller.scene.scale;
         }
-        [self.metalView updateWordVertices:_vertices colors:_colours texCoords:_coordinates wordCount:_numberOfWords scale:sceneScale];
+        [self.metalView updateWordVertices:_vertices colors:_colours texCoords:_coordinates highlighted:_highlighted wordCount:_numberOfWords scale:sceneScale];
         [self updateMetalGuideVerticesWithScale:sceneScale];
     }
 }


### PR DESCRIPTION
## Summary

Restores the two-pass word draw in the Metal renderer so highlighted words are drawn after — and therefore in front of — unhighlighted ones.

Also serializes renderer state updates with Metal command encoding so the newly retained highlight buffer cannot be reallocated while a frame is reading it.

## Why

The OpenGL renderer drew words in two passes. During the main loop it collected highlighted words into a `highlightedIndices` array and skipped them, then drew them afterwards, so a highlighted word was never occluded by its neighbours.

The Metal migration (e844e2f) carried over the highlight-state plumbing but not the behaviour. `WordClockRenderView` continued to populate `_highlighted`, but `WordClockMetalRenderer` drew straight through `0..<_wordCount` in word order and never read those flags. This is most visible in the rotary layout, where words overlap heavily.

The render view and `MTKView` run separate display callbacks. Retaining the flags in a `realloc`-backed renderer buffer therefore introduced a second issue: an update could move or free that buffer while the draw callback was traversing it.

## Review Notes

Start with `WordClockMetalRenderer.m`:

- The word draw loop now runs twice, drawing unhighlighted words first and highlighted words second.
- Highlight flags travel through `updateWordVertices:` so they use the same word count as the geometry they describe.
- An `NSLock` serializes renderer-state mutation with command encoding, protecting the highlight array and the Metal buffers and textures read during a frame.
- If highlight-buffer allocation fails, the renderer falls back to the previous single-pass word order.

The remaining edits only pass the highlight array through `WordClockRenderView` and `WordClockMetalView` to the renderer.

No durable documentation changes are needed. This restores internal rendering semantics without changing the public interface, setup, release process, or the existing documented Metal architecture.

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (371 tests)
- `xcrun clang-format --dry-run --Werror packages/wordclock-macos/WordClockCoreMac/WordClockMetalRenderer.m`
- `xcodebuild -workspace WordClock.xcworkspace -scheme "Word Clock" -configuration Release -quiet clean build`
- `xcodebuild -workspace WordClock.xcworkspace -scheme "Word Clock Window" -configuration Release -quiet clean build`
- Existing manual check in the rotary layout confirmed highlighted words no longer disappear behind neighbouring rings.

Xcode auto-bumps `CFBundleVersion` in both Info.plists during builds; those generated changes are deliberately excluded from this PR.

## Risk

Low and confined to renderer ordering and synchronization. The lock is held only while renderer state is updated or a frame's commands are encoded, so the tradeoff is brief contention between the two display callbacks. Geometry, colour, and texture formats are unchanged. On highlight-buffer allocation failure, behaviour falls back to the pre-PR single-pass order.

The PR remains a draft pending any desired comparison with an older OpenGL build. `ENABLE_CULL` is also compiled out in the current build, so the culled path this mirrors is not exercised today.
