### PR TITLE
Add support section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ pnpm build
 pnpm test
 ```
 
+## Support
+
+Word Clock is free. If you like it, [there's a tip jar](https://github.com/sponsors/simonheys).
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
Adds a short Support section above License, using the same wording as the release footer so the ask reads identically everywhere it appears:

> Word Clock is free. If you like it, [there's a tip jar](https://github.com/sponsors/simonheys).

Worth saying plainly: this is the weakest of the asks. README readers are developers, and the audience that actually converts is the ~9,400 people who download the DMG. It costs nothing and it's where people conventionally look, but it is not where the money is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)