### PR TITLE
Add tip jar link to macOS preferences panel

### DIFF
--- a/packages/wordclock-macos/WordClockOptionsWindowController.m
+++ b/packages/wordclock-macos/WordClockOptionsWindowController.m
@@ -432,4 +432,9 @@
     [[NSWorkspace sharedWorkspace] openURL:url];
 }
 
+- (IBAction)tipJarTapped:(id)sender {
+    NSURL *url = [NSURL URLWithString:@"https://github.com/sponsors/simonheys"];
+    [[NSWorkspace sharedWorkspace] openURL:url];
+}
+
 @end

--- a/packages/wordclock-macos/WordClockOptionsWindowController.xib
+++ b/packages/wordclock-macos/WordClockOptionsWindowController.xib
@@ -275,6 +275,22 @@ DQ
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Tip-Jr-Fld">
+                        <rect key="frame" x="382" y="23" width="148" height="14"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <gestureRecognizers>
+                            <clickGestureRecognizer delaysPrimaryMouseButtonEvents="YES" numberOfClicksRequired="1" id="Tip-Jr-Ges">
+                                <connections>
+                                    <action selector="tipJarTapped:" target="-2" id="Tip-Jr-Act"/>
+                                </connections>
+                            </clickGestureRecognizer>
+                        </gestureRecognizers>
+                        <textFieldCell key="cell" enabled="NO" alignment="left" title="Support Word Clock" usesSingleLineMode="YES" id="Tip-Jr-Cel">
+                            <font key="font" metaFont="smallSystem"/>
+                            <color key="textColor" name="linkColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7R6-q2-h5G">
                         <rect key="frame" x="538" y="13" width="96" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>


### PR DESCRIPTION
Adds a "Support Word Clock" link to the bottom of the preferences panel, opening the GitHub Sponsors page.

Most people install the screen saver and never return to GitHub, so the Sponsor button, README and release footer never reach them. This is the one ask that does, and it appears while they are actively using the thing.

## Changes

**`WordClockOptionsWindowController.xib`** — a non-editable `NSTextField` with a `clickGestureRecognizer`, mirroring the existing copyright line. Positioned at `x=382, y=23`, in the gap between the copyright field (ends at x=374) and the buttons (start at x=538).

**`WordClockOptionsWindowController.m`** — `tipJarTapped:` opens the sponsors page via `NSWorkspace`, alongside the existing `textTapped:`.

It uses `linkColor` rather than the copyright line's `secondaryLabelColor`. The copyright text is already clickable and nothing signals that it is, which is harmless for a copyright notice but would make a call to action invisible.

## Testing

Built and ran the `Word Clock Window` scheme, opened the Options panel, and confirmed the link renders in the bottom row and opens the sponsors page.

`ibtool` compiles the XIB with no new errors or warnings.

## Worth a look when reviewing

- **Placement and colour** in the bottom row. Easiest to judge by running the `Word Clock Window` scheme and clicking Options.
- **The wording.** "Support Word Clock" was chosen over "Tip jar", which is shorter but cryptic without the surrounding context that carries it elsewhere.
